### PR TITLE
fix:Remove unused semantic-release plugins and update CHANGELOG

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,8 +212,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v6
         with:
           extra_plugins: |
-            @semantic-release/changelog@6.0.3
-            @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@9.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,22 +23,6 @@
           "labels": false,
           "releasedLabels": false
         }
-      ],
-      [
-        "@semantic-release/changelog",
-        {
-          "changelogFile": "CHANGELOG.md",
-          "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
-        }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "CHANGELOG.md"
-          ],
-          "message": "chore(release): version ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
       ]
     ]
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
-# [unreleased]
+## [unreleased]
 
-## 🚀 Features
+### 🚀 Features
 
-- Initial release of the AWS Terraform module for Security Group and Rules
+- [**breaking**] Add AWS S3 bucket module with encryption and versioning support
+- *(aws-s3-bucket)* Add public access block and bucket policy support
+- [**breaking**] Reorganize examples and add event notification module
+
+### 🐛 Bug Fixes
+
+- *(aws-s3-bucket)* Improve CI workflow and validation logic
+- *(aws-s3-bucket)* Handle versioning state transitions correctly
+- *(aws-s3-bucket)* Simplify versioning status logic
+- *(aws-s3-bucket)* Add dependency ordering for bucket policy
+
+### 🚜 Refactor
+
+- *(aws-s3-bucket)* Rename module and standardize output naming
+- Rename folders example from with-folders to folders
+
+### 📚 Documentation
+
+- Update CHANGELOG.md [skip ci]
+- Update CHANGELOG.md [skip ci]
+- Update CHANGELOG.md [skip ci]
+- *(readme)* Update documentation with bucket policy and resources
+- Update CHANGELOG.md [skip ci]
+- Update repository references from terraform-aws-s3-bucket to terraform-aws-s3
+- Update module source references and standardize outputs
+- Update CHANGELOG.md [skip ci]
+- Update CHANGELOG.md [skip ci]
+
+### 🎨 Styling
+
+- *(aws-s3-bucket)* Align variable definitions for consistency
+- *(bucket)* Remove extra blank line in main.tf
+
+### 🧪 Testing
+
+- Refactor test suite and standardize output naming
+
+### ⚙️ Miscellaneous Tasks
+
+- Fix AWS credentials and improve git workflow
+- Update module path references from aws-s3-bucket to bucket
+- Update module source references from aws-s3-bucket to bucket
+- *(release)* Version 1.0.0 [skip ci]
+- Update CI workflow to include examples and test directories; refine security group tests
+- Remove unused semantic-release plugins from configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
-                "@semantic-release/changelog": "^6.0.1",
                 "@semantic-release/commit-analyzer": "^13.0.1",
-                "@semantic-release/git": "^10.0.1",
                 "@semantic-release/github": "^12.0.6",
                 "@semantic-release/release-notes-generator": "^14.1.0",
                 "conventional-changelog-conventionalcommits": "^9.3.1",
@@ -324,25 +322,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@semantic-release/changelog": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-            "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^3.0.0",
-                "fs-extra": "^11.0.0",
-                "lodash": "^4.17.4"
-            },
-            "engines": {
-                "node": ">=14.17"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=18.0.0"
-            }
-        },
         "node_modules/@semantic-release/commit-analyzer": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
@@ -364,39 +343,6 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@semantic-release/error": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-            "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
-        "node_modules/@semantic-release/git": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-            "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@semantic-release/error": "^3.0.0",
-                "aggregate-error": "^3.0.0",
-                "debug": "^4.0.0",
-                "dir-glob": "^3.0.0",
-                "execa": "^5.0.0",
-                "lodash": "^4.17.4",
-                "micromatch": "^4.0.0",
-                "p-reduce": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.17"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=18.0.0"
             }
         },
         "node_modules/@semantic-release/github": {
@@ -851,20 +797,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ansi-escapes": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
@@ -993,16 +925,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/cli-highlight": {
@@ -1706,43 +1628,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/execa/node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/fast-content-type-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -2025,16 +1910,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2085,16 +1960,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/index-to-position": {
@@ -2186,19 +2051,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2356,13 +2208,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lodash-es": {
             "version": "4.17.23",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
@@ -2513,16 +2358,6 @@
             },
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/minimist": {
@@ -2767,19 +2602,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/npm/node_modules/@isaacs/balanced-match": {
@@ -4773,22 +4595,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/p-each-series": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -4881,16 +4687,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-reduce": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-            "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/p-timeout": {
@@ -5600,13 +5396,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/signale": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
@@ -5856,16 +5645,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
         "release": "semantic-release"
     },
     "devDependencies": {
-        "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/commit-analyzer": "^13.0.1",
-        "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "conventional-changelog-conventionalcommits": "^9.3.1",


### PR DESCRIPTION
This pull request removes the use of the `@semantic-release/changelog` and `@semantic-release/git` plugins from the release process and updates related configuration and documentation. The changes streamline the release workflow by eliminating these plugins from the CI configuration, the `.releaserc.json` file, and `package.json`. The changelog has also been updated to reflect recent features, bug fixes, refactors, documentation, styling, testing, and miscellaneous improvements.

**Release process simplification:**

* Removed `@semantic-release/changelog` and `@semantic-release/git` from the list of plugins in the CI workflow configuration (`.github/workflows/ci.yaml`).
* Deleted configuration blocks for `@semantic-release/changelog` and `@semantic-release/git` from `.releaserc.json`.
* Removed `@semantic-release/changelog` and `@semantic-release/git` from `devDependencies` in `package.json`.

**Documentation and changelog updates:**

* Updated `CHANGELOG.md` with new features, bug fixes, refactors, documentation improvements, styling changes, testing updates, and miscellaneous tasks.